### PR TITLE
Use pointers instead of values for Collector interface

### DIFF
--- a/logs/logs_test.go
+++ b/logs/logs_test.go
@@ -318,7 +318,7 @@ func TestRefreshLogList(t *testing.T) {
 		l := Logs{}
 		l.loadConfig(cfg)
 		l.refreshLogList(mts)
-		So(logFiles, ShouldResemble, []string{"logdira/testfile2", "logdira/testfile3", "logdirb/testfile2", "logdirb/testfile3"})
+		So(l.logFiles, ShouldResemble, []string{"logdira/testfile2", "logdira/testfile3", "logdirb/testfile2", "logdirb/testfile3"})
 	})
 
 	Convey("should list only logs in namespace log_file entry", t, func() {
@@ -331,7 +331,7 @@ func TestRefreshLogList(t *testing.T) {
 		l := Logs{}
 		l.loadConfig(cfg)
 		l.refreshLogList(mts)
-		So(logFiles, ShouldResemble, []string{"logdira/testfile2", "logdirb/testfile2", "logdirc/testfile2"})
+		So(l.logFiles, ShouldResemble, []string{"logdira/testfile2", "logdirb/testfile2", "logdirc/testfile2"})
 	})
 
 	os.Remove("logdira/testfile1")
@@ -579,7 +579,7 @@ func TestCollectMetrics(t *testing.T) {
 		// Should refresh log files list after each collection cycle
 		os.Remove("logdir/testapache.log")
 		l.CollectMetrics(mtsApache)
-		So(logFiles, ShouldBeEmpty)
+		So(l.logFiles, ShouldBeEmpty)
 	})
 
 	Convey("should collect valid metrics and create valid cache file (Apache - new line based)", t, func() {
@@ -614,7 +614,7 @@ func TestCollectMetrics(t *testing.T) {
 		// Should refresh log files list after each collection cycle
 		os.Remove("logdir/testapachenewline.log")
 		l.CollectMetrics(mtsApacheNewline)
-		So(logFiles, ShouldBeEmpty)
+		So(l.logFiles, ShouldBeEmpty)
 	})
 
 	Convey("should collect valid metrics and create valid cache file (Apache multiline - date based)", t, func() {
@@ -638,7 +638,7 @@ func TestCollectMetrics(t *testing.T) {
 		// Should refresh log files list after each collection cycle
 		os.Remove("logdir/testapachemultiline.log")
 		l.CollectMetrics(mtsApacheMultiline)
-		So(logFiles, ShouldBeEmpty)
+		So(l.logFiles, ShouldBeEmpty)
 	})
 
 	Convey("should collect valid metrics and create valid cache file (Rabbit)", t, func() {
@@ -662,13 +662,13 @@ func TestCollectMetrics(t *testing.T) {
 		// Should refresh log files list after 3 collection cycles
 		os.Remove("logdir/testrabbit.log")
 		l.CollectMetrics(mtsRabbit)
-		So(logFiles, ShouldNotBeEmpty)
+		So(l.logFiles, ShouldNotBeEmpty)
 		l.CollectMetrics(mtsRabbit)
-		So(logFiles, ShouldNotBeEmpty)
+		So(l.logFiles, ShouldNotBeEmpty)
 		l.CollectMetrics(mtsRabbit)
-		So(logFiles, ShouldNotBeEmpty)
+		So(l.logFiles, ShouldNotBeEmpty)
 		l.CollectMetrics(mtsRabbit)
-		So(logFiles, ShouldBeEmpty) // <- 4th collection - list should be updated now
+		So(l.logFiles, ShouldBeEmpty) // <- 4th collection - list should be updated now
 	})
 
 	os.Remove("logdir/testapache.log")

--- a/main.go
+++ b/main.go
@@ -29,5 +29,5 @@ import (
 
 func main() {
 	// Start a collector
-	plugin.StartCollector(logs.Logs{}, logs.Name, logs.Version, plugin.RoutingStrategy(plugin.StickyRouter))
+	plugin.StartCollector(logs.New(), logs.Name, logs.Version, plugin.RoutingStrategy(plugin.StickyRouter))
 }


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Plugin was based on snap-plugin-lib-go examples, which uses object copies instead of pointers for Collector interface methods. As plugin uses some global variables, I moved it to Logs plugin struct and replaced method parent types to pointer, so global variables inside plugin struct can be modified, for example:

```
func (l Logs) CollectMetrics(mts []plugin.Metric) ([]plugin.Metric, error)
```

to

```
func (l *Logs) CollectMetrics(mts []plugin.Metric) ([]plugin.Metric, error)
```

This PR just makes code more clear and consistent with other plugins.